### PR TITLE
Add SetStage() calls to ICC encounters for phase tracking

### DIFF
--- a/Citadel/BloodCouncil.lua
+++ b/Citadel/BloodCouncil.lua
@@ -86,7 +86,7 @@ function mod:Switch(args)
 		self:PrimaryIcon("iconprince", boss)
 		-- Set stage depending on active boss
 		local guid = self:MobId(args.destGUID)
-		if guid
+		if guid then
 			if guid == 37970 then -- Prince Valanar
 				self:SetStage(1)
 			elseif guid == 37972 then -- Prince Keleseth

--- a/Citadel/BloodCouncil.lua
+++ b/Citadel/BloodCouncil.lua
@@ -14,6 +14,7 @@ mod.optionHeaders = {
 	[72999] = "heroic",
 	[70981] = "general",
 }
+mod:SetStage(1)
 
 --------------------------------------------------------------------------------
 -- Localization
@@ -56,6 +57,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
+	self:SetStage(1)
 	self:CDBar(70981, 45, L["switch_bar"])
 	self:CDBar(72037, 20, L["shock_bar"])
 	self:Berserk(600)
@@ -82,7 +84,19 @@ function mod:Switch(args)
 	local boss = self:GetUnitIdByGUID(args.destGUID)
 	if boss then
 		self:PrimaryIcon("iconprince", boss)
+		-- Set stage depending on active boss
+		local guid = self:MobId(args.destGUID)
+		if guid
+			if guid == 37970 then -- Prince Valanar
+				self:SetStage(1)
+			elseif guid == 37972 then -- Prince Keleseth
+				self:SetStage(2)
+			elseif guid == 37973 then -- Prince Taldaram
+				self:SetStage(3)
+			end
+		end
 	end
+	
 end
 
 function mod:EmpoweredShock(_, spellId)

--- a/Citadel/BloodCouncil.lua
+++ b/Citadel/BloodCouncil.lua
@@ -96,7 +96,6 @@ function mod:Switch(args)
 			end
 		end
 	end
-	
 end
 
 function mod:EmpoweredShock(_, spellId)

--- a/Citadel/Deathwhisper.lua
+++ b/Citadel/Deathwhisper.lua
@@ -13,6 +13,7 @@ mod.optionHeaders = {
 	[71204] = CL.phase:format(2),
 	[71289] = "general",
 }
+mod:SetStage(1)
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -71,6 +72,7 @@ local function adds(time)
 end
 
 function mod:OnEngage(diff)
+	self:SetStage(1)
 	self:Berserk(600, true)
 	self:Bar("adds", 7, L["adds_bar"], 70768)
 	if diff > 3 then
@@ -91,6 +93,7 @@ function mod:DnD(args)
 end
 
 function mod:Barrier(args)
+	self:SetStage(2)
 	if not self:Heroic() then
 		self:CancelTimer(handle_Adds)
 		self:StopBar(L["adds_bar"])

--- a/Citadel/Festergut.lua
+++ b/Citadel/Festergut.lua
@@ -54,7 +54,6 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	self:SetStage(1)
 	count = 1
 	self:Berserk(300, true)
 	self:CDBar(69279, 20) -- Gas Spore

--- a/Citadel/Festergut.lua
+++ b/Citadel/Festergut.lua
@@ -13,6 +13,7 @@ mod.optionHeaders = {
 	[72295] = "heroic",
 	proximity = "general",
 }
+mod:SetStage(1)
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -53,6 +54,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
+	self:SetStage(1)
 	count = 1
 	self:Berserk(300, true)
 	self:CDBar(69279, 20) -- Gas Spore

--- a/Citadel/Gunship.lua
+++ b/Citadel/Gunship.lua
@@ -77,7 +77,6 @@ do
 end
 
 function mod:Warmup()
-	self:SetStage(1)
 	self:Bar("adds", 45, COMBAT, "achievement_dungeon_hordeairship")
 	--XXX Fix me, move to engage, need more logs for testing
 	self:Bar("adds", 60, L["adds_bar"], 53142)

--- a/Citadel/Gunship.lua
+++ b/Citadel/Gunship.lua
@@ -8,6 +8,7 @@ mod:RegisterEnableMob(37184) -- Zafod Boombox
 -- mod:SetEncounterID(1099)
 -- mod:SetRespawnTime(30)
 mod.toggleOptions = {"adds", "mage"}
+mod:SetStage(1)
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -76,6 +77,7 @@ do
 end
 
 function mod:Warmup()
+	self:SetStage(1)
 	self:Bar("adds", 45, COMBAT, "achievement_dungeon_hordeairship")
 	--XXX Fix me, move to engage, need more logs for testing
 	self:Bar("adds", 60, L["adds_bar"], 53142)

--- a/Citadel/Lanathel.lua
+++ b/Citadel/Lanathel.lua
@@ -8,6 +8,7 @@ mod:RegisterEnableMob(37955)
 -- mod:SetEncounterID(1103)
 -- mod:SetRespawnTime(30)
 mod.toggleOptions = {{71340, "FLASH"}, {71265, "FLASH"}, 70877, 71772, 71623, "proximity", "berserk"}
+mod:SetStage(1)
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -65,6 +66,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage(diff)
+	self:SetStage(1)
 	self:Berserk(320, true)
 	self:OpenProximity("proximity", 6)
 	self:Bar(71772, airPhaseTimers[diff][1], L["phase2_bar"])
@@ -110,9 +112,15 @@ function mod:Feed(args)
 end
 
 function mod:AirPhase(args)
+	self:SetStage(1.5)
 	self:MessageOld(71772, "red", "alarm", L["phase_message"])
 	self:Bar(71772, 12, L["phase1_bar"])
 	self:Bar(71772, airPhaseTimers[self:Difficulty()][2], L["phase2_bar"])
+	self:ScheduleTimer("GroundPhase", airPhaseTimers[self:Difficulty()][2])
+end
+
+function mod:GroundPhase()
+	self:SetStage(1)
 end
 
 function mod:Slash(args)

--- a/Citadel/LichKing.lua
+++ b/Citadel/LichKing.lua
@@ -16,6 +16,7 @@ mod.optionHeaders = {
 	[73529] = "heroic",
 	warmup = "general",
 }
+mod:SetStage(1)
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -104,6 +105,7 @@ function mod:Warmup()
 end
 
 function mod:OnEngage()
+	self:SetStage(1)
 	frenzied = {}
 	plagueTicks = {}
 	valkyrs = {}
@@ -316,6 +318,7 @@ end
 
 function mod:RemorselessWinter(args)
 	phase = phase + 1
+	self:SetStage(phase) -- Phase 2, and 4 is transition phases
 	self:StopBar(L["valkyr_bar"])
 	self:StopBar(L["horror_bar"])
 	self:StopBar(70337) -- Necrotic Plague
@@ -331,6 +334,7 @@ end
 
 function mod:Quake(args)
 	phase = phase + 1
+	self:SetStage(phase)
 	self:StopBar(69200) -- Raging Spirit
 	self:MessageOld(72262, "orange", "long", CL["cast"]:format(args.spellName))
 	self:Bar(72762, 37) -- Defile

--- a/Citadel/Marrowgar.lua
+++ b/Citadel/Marrowgar.lua
@@ -39,7 +39,6 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	self:SetStage(1)
 	self:CDBar(69076, 45)
 	self:DelayedMessage(69076, 40, "yellow", L["bonestorm_warning"])
 end
@@ -72,7 +71,6 @@ end
 
 do
 	local function afterTheStorm()
-		self:SetStage(1)
 		if mod:Heroic() then
 			mod:Bar(69076, 55)
 			mod:DelayedMessage(69076, 50, "yellow", L["bonestorm_warning"])
@@ -83,7 +81,6 @@ do
 		end
 	end
 	function mod:Bonestorm(args)
-		self:SetStage(2)
 		if not self:Heroic() then
 			self:StopBar(69062) -- Impale
 		end

--- a/Citadel/Marrowgar.lua
+++ b/Citadel/Marrowgar.lua
@@ -8,6 +8,7 @@ mod:RegisterEnableMob(36612)
 -- mod:SetEncounterID(1101)
 -- mod:SetRespawnTime(30)
 mod.toggleOptions = {69076, 69057, {69138, "FLASH"}}
+mod:SetStage(1)
 
 --------------------------------------------------------------------------------
 -- Localization
@@ -38,6 +39,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
+	self:SetStage(1)
 	self:CDBar(69076, 45)
 	self:DelayedMessage(69076, 40, "yellow", L["bonestorm_warning"])
 end
@@ -70,6 +72,7 @@ end
 
 do
 	local function afterTheStorm()
+		self:SetStage(1)
 		if mod:Heroic() then
 			mod:Bar(69076, 55)
 			mod:DelayedMessage(69076, 50, "yellow", L["bonestorm_warning"])
@@ -80,6 +83,7 @@ do
 		end
 	end
 	function mod:Bonestorm(args)
+		self:SetStage(2)
 		if not self:Heroic() then
 			self:StopBar(69062) -- Impale
 		end

--- a/Citadel/Putricide.lua
+++ b/Citadel/Putricide.lua
@@ -99,12 +99,12 @@ do
 			mod:Bar(70351, 25, L["experiment_bar"])
 			first = true
 			p2 = true
-			self:SetStage(2)
+			mod:SetStage(2)
 		else
 			mod:MessageOld("phase", "green", nil, CL.phase:format(3), false)
 			first = nil
 			mod:UnregisterEvent("UNIT_HEALTH")
-			self:SetStage(3)
+			mod:SetStage(3)
 		end
 	end
 

--- a/Citadel/Putricide.lua
+++ b/Citadel/Putricide.lua
@@ -95,13 +95,11 @@ do
 		mod:Bar(71255, 14, L["gasbomb_bar"])
 		mod:Bar(72295, 6, L["ball_bar"])
 		if not first then
-			self:SetStage(2)
 			mod:MessageOld("phase", "green", nil, CL.phase:format(2), false)
 			mod:Bar(70351, 25, L["experiment_bar"])
 			first = true
 			p2 = true
 		else
-			self:SetStage(3)
 			mod:MessageOld("phase", "green", nil, CL.phase:format(3), false)
 			first = nil
 			mod:UnregisterEvent("UNIT_HEALTH")
@@ -113,11 +111,9 @@ do
 		stopOldStuff()
 		self:MessageOld("phase", "red", nil, L["experiment_heroic_message"], "achievement_boss_profputricide")
 		if not first then
-			self:SetStage(1.5)
 			self:Bar("phase", 45, L["phase_bar"], "achievement_boss_profputricide")
 			self:ScheduleTimer(newPhase, 45)
 		else
-			self:SetStage(2.5)
 			self:Bar("phase", 37, L["phase_bar"], "achievement_boss_profputricide")
 			self:ScheduleTimer(newPhase, 37)
 		end
@@ -135,9 +131,9 @@ do
 		self:ScheduleTimer(nextPhase, 3)
 		stopOldStuff()
 		if not first then
-			self:SetStage(1.5)
+			self:SetStage(2)
 		else
-			self:SetStage(2.5)
+			self:SetStage(3)
 		end
 	end
 	function mod:TearGasOver()

--- a/Citadel/Putricide.lua
+++ b/Citadel/Putricide.lua
@@ -15,6 +15,7 @@ mod.optionHeaders = {
 	[70911] = "heroic",
 	phase = "general",
 }
+mod:SetStage(1)
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -73,6 +74,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
+	self:SetStage(1)
 	self:Berserk(600)
 	p2, first = nil, nil
 	self:Bar(70351, 25, L["experiment_bar"])
@@ -93,11 +95,13 @@ do
 		mod:Bar(71255, 14, L["gasbomb_bar"])
 		mod:Bar(72295, 6, L["ball_bar"])
 		if not first then
+			self:SetStage(2)
 			mod:MessageOld("phase", "green", nil, CL.phase:format(2), false)
 			mod:Bar(70351, 25, L["experiment_bar"])
 			first = true
 			p2 = true
 		else
+			self:SetStage(3)
 			mod:MessageOld("phase", "green", nil, CL.phase:format(3), false)
 			first = nil
 			mod:UnregisterEvent("UNIT_HEALTH")
@@ -109,9 +113,11 @@ do
 		stopOldStuff()
 		self:MessageOld("phase", "red", nil, L["experiment_heroic_message"], "achievement_boss_profputricide")
 		if not first then
+			self:SetStage(1.5)
 			self:Bar("phase", 45, L["phase_bar"], "achievement_boss_profputricide")
 			self:ScheduleTimer(newPhase, 45)
 		else
+			self:SetStage(2.5)
 			self:Bar("phase", 37, L["phase_bar"], "achievement_boss_profputricide")
 			self:ScheduleTimer(newPhase, 37)
 		end
@@ -128,6 +134,11 @@ do
 		self:Bar("phase", 18, L["phase_bar"], "achievement_boss_profputricide")
 		self:ScheduleTimer(nextPhase, 3)
 		stopOldStuff()
+		if not first then
+			self:SetStage(1.5)
+		else
+			self:SetStage(2.5)
+		end
 	end
 	function mod:TearGasOver()
 		if stop then return end

--- a/Citadel/Putricide.lua
+++ b/Citadel/Putricide.lua
@@ -131,7 +131,6 @@ do
 		stop = true
 		self:Bar("phase", 18, L["phase_bar"], "achievement_boss_profputricide")
 		self:ScheduleTimer(nextPhase, 3)
-		self:SetStage(self:GetStage()+0.5) -- Half stage during transition
 		stopOldStuff()
 	end
 	function mod:TearGasOver()

--- a/Citadel/Putricide.lua
+++ b/Citadel/Putricide.lua
@@ -99,10 +99,12 @@ do
 			mod:Bar(70351, 25, L["experiment_bar"])
 			first = true
 			p2 = true
+			self:SetStage(2)
 		else
 			mod:MessageOld("phase", "green", nil, CL.phase:format(3), false)
 			first = nil
 			mod:UnregisterEvent("UNIT_HEALTH")
+			self:SetStage(3)
 		end
 	end
 
@@ -129,12 +131,8 @@ do
 		stop = true
 		self:Bar("phase", 18, L["phase_bar"], "achievement_boss_profputricide")
 		self:ScheduleTimer(nextPhase, 3)
+		self:SetStage(self:GetStage()+0.5) -- Half stage during transition
 		stopOldStuff()
-		if not first then
-			self:SetStage(2)
-		else
-			self:SetStage(3)
-		end
 	end
 	function mod:TearGasOver()
 		if stop then return end

--- a/Citadel/Rotface.lua
+++ b/Citadel/Rotface.lua
@@ -13,6 +13,7 @@ mod.optionHeaders = {
 	[72272] = "heroic",
 	berserk = "general",
 }
+mod:SetStage(1)
 
 --------------------------------------------------------------------------------
 -- Localization
@@ -51,6 +52,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
+	self:SetStage(1)
 	self:Berserk(600, true)
 	self:Bar(69508, 19, L["spray_bar"])
 	if self:Heroic() then

--- a/Citadel/Rotface.lua
+++ b/Citadel/Rotface.lua
@@ -52,7 +52,6 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	self:SetStage(1)
 	self:Berserk(600, true)
 	self:Bar(69508, 19, L["spray_bar"])
 	if self:Heroic() then

--- a/Citadel/Saurfang.lua
+++ b/Citadel/Saurfang.lua
@@ -59,7 +59,6 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	self:SetStage(1)
 	self:OpenProximity("proximity", 11)
 	self:Berserk(self:Heroic() and 360 or 480)
 	self:DelayedMessage("adds", 35, "orange", L["adds_warning"])
@@ -120,7 +119,6 @@ function mod:Mark(args)
 end
 
 function mod:Frenzy(args)
-	self:SetStage(2)
 	self:MessageOld(72737, "red", "long")
 end
 

--- a/Citadel/Saurfang.lua
+++ b/Citadel/Saurfang.lua
@@ -8,6 +8,7 @@ mod:RegisterEnableMob(37813, 37200, 37830, 37187, 37920) -- Deathbringer Saurfan
 -- mod:SetEncounterID(1096)
 -- mod:SetRespawnTime(30)
 mod.toggleOptions = {"warmup", "adds", 72410, 72385, {72293, "ICON", "FLASH"}, 72737, "proximity", "berserk"}
+mod:SetStage(1)
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -58,6 +59,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
+	self:SetStage(1)
 	self:OpenProximity("proximity", 11)
 	self:Berserk(self:Heroic() and 360 or 480)
 	self:DelayedMessage("adds", 35, "orange", L["adds_warning"])
@@ -118,6 +120,7 @@ function mod:Mark(args)
 end
 
 function mod:Frenzy(args)
+	self:SetStage(2)
 	self:MessageOld(72737, "red", "long")
 end
 

--- a/Citadel/Sindragosa.lua
+++ b/Citadel/Sindragosa.lua
@@ -7,6 +7,7 @@ if not mod then return end
 mod:RegisterEnableMob(36853, 37533, 37534) -- Sindragosa, Rimefang, Spinestalker
 -- mod:SetEncounterID(1105)
 -- mod:SetRespawnTime(30)
+mod:SetStage(1)
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -99,6 +100,7 @@ function mod:Warmup()
 end
 
 function mod:OnEngage(diff)
+	self:SetStage(1)
 	phase = 1
 	beaconCount = 1
 	self:Berserk(600)
@@ -155,14 +157,23 @@ function mod:Grip()
 end
 
 function mod:AirPhase()
+	self:SetStage(1.5)
 	beaconCount = 1
 	self:MessageOld("airphase", "green", nil, L["airphase_message"], 23684)
 	self:Bar("airphase", 110, L["airphase_bar"], 23684)
 	self:Bar(70123, 80, 70117) -- Icy Grip
 	self:Bar(69762, 57) -- Unchained Magic
+	self:ScheduleTimer("GroundPhase", 20)
+end
+
+function mod:GroundPhase()
+	if self:GetStage() ~= 2 then
+		self:SetStage(1)
+	end
 end
 
 function mod:Phase2()
+	self:SetStage(2)
 	phase = 2
 	self:StopBar(L["airphase_bar"])
 	self:MessageOld("phase2", "green", "long", L["phase2_message"], false)

--- a/Citadel/Valithria.lua
+++ b/Citadel/Valithria.lua
@@ -12,6 +12,7 @@ mod.optionHeaders = {
 	[69325] = "normal",
 	berserk = "heroic",
 }
+mod:SetStage(1)
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -86,6 +87,7 @@ do
 		end
 	end
 	function mod:OnEngage()
+		self:SetStage(1)
 		portalCount = 1
 		if self:Heroic() then
 			self:CDBar("suppresser", 14, L["suppresser_message"], 70588)

--- a/Citadel/Valithria.lua
+++ b/Citadel/Valithria.lua
@@ -87,7 +87,6 @@ do
 		end
 	end
 	function mod:OnEngage()
-		self:SetStage(1)
 		portalCount = 1
 		if self:Heroic() then
 			self:CDBar("suppresser", 14, L["suppresser_message"], 70588)


### PR DESCRIPTION
Adds a SetStage(phase) call to all the ICC encounters.

It is currently untested as no PTR available
Changes should be minimal enough to not be breaking.